### PR TITLE
Uptime edge cases

### DIFF
--- a/src/clojurefetch/core.clj
+++ b/src/clojurefetch/core.clj
@@ -23,11 +23,14 @@
         total (count (str/split-lines (str (:out list))))]
     (str total " (portage)")))
 
-(defn Uptime []
+(defn read-uptime []
   (let [uptime_raw (str (trim-and-slurp (java.io.FileReader. "/proc/uptime")))
         uptime_vector (str/split uptime_raw #"\.")
-        uptime (Integer. (first uptime_vector))
-        days (if (> uptime 86400)
+        uptime (Integer. (first uptime_vector))]
+    uptime))
+
+(defn uptime->string [uptime]
+  (let [days (if (> uptime 86400)
                (str (int (/ uptime 60 60 24)) "d")
                "")
         hours (if (> uptime 3600)
@@ -81,4 +84,4 @@ p     portage (requires qlist until I can figure out globbing)"))
         (when (str/includes? cargs "U")
           (println (str "User:      " (System/getenv "USER"))))
         (when (str/includes? cargs "u")
-          (println (str "Uptime:    " (Uptime))))))))
+          (println (str "Uptime:    " (uptime->string (read-uptime)))))))))

--- a/src/clojurefetch/core.clj
+++ b/src/clojurefetch/core.clj
@@ -30,13 +30,13 @@
     uptime))
 
 (defn uptime->string [uptime]
-  (let [days (if (> uptime 86400)
+  (let [days (if (>= uptime 86400)
                (str (int (/ uptime 60 60 24)) "d")
                "")
-        hours (if (> uptime 3600)
+        hours (if (>= uptime 3600)
                 (str (int (rem (/ uptime 60 60) 24)) "h")
                 "")
-        minutes (if (> uptime 60)
+        minutes (if (>= uptime 60)
                   (str (int (rem (/ uptime 60) 60)) "m")
                   "")]
   (str/trim (str days " " hours " " minutes))))

--- a/src/clojurefetch/core.clj
+++ b/src/clojurefetch/core.clj
@@ -24,22 +24,28 @@
     (str total " (portage)")))
 
 (defn read-uptime []
-  (let [uptime_raw (str (trim-and-slurp (java.io.FileReader. "/proc/uptime")))
-        uptime_vector (str/split uptime_raw #"\.")
-        uptime (Integer. (first uptime_vector))]
-    uptime))
+  (let [uptime-raw (trim-and-slurp (java.io.FileReader. "/proc/uptime"))
+        ;; /proc/uptime contains two fields separated by a space:
+        ;;   1. The system's uptime represented in seconds
+        ;;   2. The sum of each core's idle time
+        ;; Example: 1994.80 3679.13
+        ;; To calculate the uptime we only want the first value without the fractional part.
+        uptime-string (first (str/split uptime-raw #"\."))]
+    (Integer. uptime-string)))
 
 (defn uptime->string [uptime]
-  (let [days (if (>= uptime 86400)
-               (str (int (/ uptime 60 60 24)) "d")
-               "")
-        hours (if (>= uptime 3600)
-                (str (int (rem (/ uptime 60 60) 24)) "h")
-                "")
-        minutes (if (>= uptime 60)
-                  (str (int (rem (/ uptime 60) 60)) "m")
-                  "")]
-  (str/trim (str days " " hours " " minutes))))
+  (if (< uptime 60)
+    "<1m" ;; Return "<1m" if uptime is under a minute.
+    (let [days (if (>= uptime 86400)
+                 (str (int (/ uptime 60 60 24)) "d ")
+                 "")
+          hours (if (>= uptime 3600)
+                  (str (int (rem (/ uptime 60 60) 24)) "h ")
+                  "")
+          minutes (if (>= uptime 60)
+                    (str (int (rem (/ uptime 60) 60)) "m")
+                    "")]
+      (str days hours minutes))))
 
 (defn display-help []
   (println "general fields:

--- a/test/clojurefetch/core_test.clj
+++ b/test/clojurefetch/core_test.clj
@@ -20,8 +20,15 @@
     (is (= "15m" (uptime->string 900)))))
 
 (deftest uptime-hour-boundary-test
-  (testing "uptimes on the hour boundary"
-    (is (= "1h" (uptime->string 3600)))))
+  (testing "Uptimes on the hour boundary"
+    (is (= "1h 0m" (uptime->string 3600)))
+    (is (= "1h 0m" (uptime->string 3601)))
+    (is (= "59m" (uptime->string 3599)))
+    (is (= "59m" (uptime->string 3540)))
+    (is (= "1h 1m" (uptime->string 3660)))
+    (is (= "1h 1m" (uptime->string 3666)))
+    (is (= "1h 30m" (uptime->string 5400)))
+    (is (= "3h 45m" (uptime->string 13500)))))
 
 (deftest uptime-day-boundary-test
   (testing "uptimes on the day boundary"

--- a/test/clojurefetch/core_test.clj
+++ b/test/clojurefetch/core_test.clj
@@ -4,10 +4,11 @@
 
 (deftest uptime-<min-test
   (testing "Uptimes less than 1 minute"
-      (is (= "" (uptime->string 0)))
-      (is (= "" (uptime->string 20)))
-      (is (= "" (uptime->string 45)))
-      (is (= "" (uptime->string 59)))))
+    (let [expected "<1m"]
+      (is (= expected (uptime->string 0)))
+      (is (= expected (uptime->string 20)))
+      (is (= expected (uptime->string 45)))
+      (is (= expected (uptime->string 59))))))
 
 (deftest uptime-min-boundary-test
   (testing "Uptimes on the minute boundary"

--- a/test/clojurefetch/core_test.clj
+++ b/test/clojurefetch/core_test.clj
@@ -31,5 +31,10 @@
     (is (= "3h 45m" (uptime->string 13500)))))
 
 (deftest uptime-day-boundary-test
-  (testing "uptimes on the day boundary"
-    (is (= "1d" (uptime->string 86400)))))
+  (testing "Uptimes on the day boundary"
+    (is (= "1d 0h 0m" (uptime->string 86400)))
+    (is (= "1d 0h 0m" (uptime->string 86401)))
+    (is (= "1d 0h 1m" (uptime->string 86460)))
+    (is (= "1d 4h 0m" (uptime->string 100800)))
+    (is (= "1d 4h 1m" (uptime->string 100860)))
+    (is (= "2d 0h 0m" (uptime->string 172800)))))

--- a/test/clojurefetch/core_test.clj
+++ b/test/clojurefetch/core_test.clj
@@ -2,13 +2,27 @@
   (:require [clojure.test :refer :all]
             [clojurefetch.core :refer :all]))
 
-(deftest uptime-test
-  (testing "Testing uptime->string:"
-    (testing "uptimes less than 1 minute"
+(deftest uptime-<min-test
+  (testing "Uptimes less than 1 minute"
       (is (= "" (uptime->string 0)))
       (is (= "" (uptime->string 20)))
       (is (= "" (uptime->string 45)))
-      (is (= "" (uptime->string 59))))
-    (testing "uptimes on the minute boundary"
-      (is (= "1m" (uptime->string 60)))
-      (is (= "2m" (uptime->string 120))))))
+      (is (= "" (uptime->string 59)))))
+
+(deftest uptime-min-boundary-test
+  (testing "Uptimes on the minute boundary"
+    (is (= "1m" (uptime->string 60)))
+    (is (= "1m" (uptime->string 67)))
+    (is (= "1m" (uptime->string 90)))
+    (is (= "2m" (uptime->string 120)))
+    (is (= "3m" (uptime->string 180)))
+    (is (= "14m" (uptime->string 899)))
+    (is (= "15m" (uptime->string 900)))))
+
+(deftest uptime-hour-boundary-test
+  (testing "uptimes on the hour boundary"
+    (is (= "1h" (uptime->string 3600)))))
+
+(deftest uptime-day-boundary-test
+  (testing "uptimes on the day boundary"
+    (is (= "1d" (uptime->string 86400)))))

--- a/test/clojurefetch/core_test.clj
+++ b/test/clojurefetch/core_test.clj
@@ -2,6 +2,13 @@
   (:require [clojure.test :refer :all]
             [clojurefetch.core :refer :all]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(deftest uptime-test
+  (testing "Testing uptime->string:"
+    (testing "uptimes less than 1 minute"
+      (is (= "" (uptime->string 0)))
+      (is (= "" (uptime->string 20)))
+      (is (= "" (uptime->string 45)))
+      (is (= "" (uptime->string 59))))
+    (testing "uptimes on the minute boundary"
+      (is (= "1m" (uptime->string 60)))
+      (is (= "2m" (uptime->string 120))))))


### PR DESCRIPTION
Clojurefetch would report weird uptimes at the 1 {minute,hour,day} mark.
- 60 seconds would give nothing.
- 1 hour would give "0m".
- 1 day would give "0h 0m".

The uptime function was split so that tests could be added and the bug was fixed.
Also a value of "<1m" is now returned for any uptimes under a minute.